### PR TITLE
fix gpu reduce scratch buffer size

### DIFF
--- a/src/core/src/utilities/gpu_reduce.cpp
+++ b/src/core/src/utilities/gpu_reduce.cpp
@@ -186,7 +186,7 @@ bool GPUReduce::reduceInternal(
     if (numGroups1 > 1 && numGroups2 > 1)
     {
         // Create scratch buffer needed for loops
-        const uint64_t typeSize          = ((uint32_t)currentType % 4) * sizeof(float);
+        const uint64_t typeSize          = ((uint32_t)currentType % 4 + 1) * sizeof(float);
         const uint64_t scratchBufferSize = maxNumKeys * typeSize;
         if (!scratchBuffer || (scratchBuffer.getSize() < scratchBufferSize))
         {


### PR DESCRIPTION
Type size should be 4-16 bytes and currently it is 0-12 bytes.