### PR TITLE
Fix max_probe_spawn_count computation

### DIFF
--- a/src/core/src/render_techniques/gi10/gi10.comp
+++ b/src/core/src/render_techniques/gi10/gi10.comp
@@ -3656,7 +3656,7 @@ void ReprojectGI(in uint2 did : SV_DispatchThreadID)
         lighting *= (max_sample_count / lighting.w);
     }
 
-    g_GIDenoiser_BlurMask[did]         = blur_mask / 127.0f;
+    g_GIDenoiser_BlurMask[did]         = blur_mask * kGIDenoiser_BlurMaskPack;
     g_GIDenoiser_ColorBuffer[did]      = lighting;
     g_GIDenoiser_ColorDeltaBuffer[did] = color_delta;
 }
@@ -3678,10 +3678,10 @@ void FilterBlurMask(in uint2 did : SV_DispatchThreadID, in uint2 lid : SV_GroupT
         int2 coord3 = anchor + int2((local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim / 2)     % kGIDenoiser_BlurTileDim, (local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim / 2)     / kGIDenoiser_BlurTileDim);
         int2 coord4 = anchor + int2((local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim * 3 / 4) % kGIDenoiser_BlurTileDim, (local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim * 3 / 4) / kGIDenoiser_BlurTileDim);
 
-        float blur_mask_0 = g_GIDenoiser_BlurMask[clamp(coord1, 0, int2(g_BufferDimensions) - 1)].x;
-        float blur_mask_1 = g_GIDenoiser_BlurMask[clamp(coord2, 0, int2(g_BufferDimensions) - 1)].x;
-        float blur_mask_2 = g_GIDenoiser_BlurMask[clamp(coord3, 0, int2(g_BufferDimensions) - 1)].x;
-        float blur_mask_3 = g_GIDenoiser_BlurMask[clamp(coord4, 0, int2(g_BufferDimensions) - 1)].x;
+        float blur_mask_0 = g_GIDenoiser_BlurMask[clamp(coord1, 0, int2(g_BufferDimensions) - 1)].x * kGIDenoiser_BlurMaskUnpack;
+        float blur_mask_1 = g_GIDenoiser_BlurMask[clamp(coord2, 0, int2(g_BufferDimensions) - 1)].x * kGIDenoiser_BlurMaskUnpack;
+        float blur_mask_2 = g_GIDenoiser_BlurMask[clamp(coord3, 0, int2(g_BufferDimensions) - 1)].x * kGIDenoiser_BlurMaskUnpack;
+        float blur_mask_3 = g_GIDenoiser_BlurMask[clamp(coord4, 0, int2(g_BufferDimensions) - 1)].x * kGIDenoiser_BlurMaskUnpack;
 
         lds_GIDenoiser_BlurMask[local_id]                                                             = blur_mask_0;
         lds_GIDenoiser_BlurMask[local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim / 4]     = blur_mask_1;
@@ -3725,7 +3725,7 @@ void FilterBlurMask(in uint2 did : SV_DispatchThreadID, in uint2 lid : SV_GroupT
         InterlockedAdd(g_GIDenoiser_BlurSampleCountBuffer[0], lds_GIDenoiser_BlurSampleCount);
     }
 
-    g_GIDenoiser_BlurredBlurMask[did] = blur_mask;
+    g_GIDenoiser_BlurredBlurMask[did] = blur_mask * kGIDenoiser_BlurMaskPack;
 }
 
 [numthreads(8, 8, 1)]

--- a/src/core/src/render_techniques/gi10/gi10.comp
+++ b/src/core/src/render_techniques/gi10/gi10.comp
@@ -629,8 +629,8 @@ void PatchScreenProbes(in uint did : SV_DispatchThreadID)
 [numthreads(64, 1, 1)]
 void SampleScreenProbes(in uint did : SV_DispatchThreadID, in uint local_id : SV_GroupThreadID)
 {
-    uint max_probe_spawn_count = (g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size
-                               * (g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size;
+    uint max_probe_spawn_count = ((g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size)
+                               * ((g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size);
     uint probe_count           = g_ScreenProbes_ProbeSpawnScanBuffer[max_probe_spawn_count - 1]
                                + g_ScreenProbes_ProbeSpawnIndexBuffer[max_probe_spawn_count - 1];
 
@@ -1096,8 +1096,8 @@ void PopulateScreenProbesTraceRay(uint did, inout PopulateScreenProbesPayload pa
 
 void PopulateScreenProbes(uint did)
 {
-    uint max_probe_spawn_count = (g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size
-                               * (g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size;
+    uint max_probe_spawn_count = ((g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size)
+                               * ((g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size);
     uint probe_count           = g_ScreenProbes_ProbeSpawnScanBuffer[max_probe_spawn_count - 1]
                                + g_ScreenProbes_ProbeSpawnIndexBuffer[max_probe_spawn_count - 1];
 
@@ -1162,8 +1162,8 @@ void PopulateScreenProbesMain(in uint did : SV_DispatchThreadID)
 [numthreads(64, 1, 1)]
 void BlendScreenProbes(in uint did : SV_DispatchThreadID, in uint local_id : SV_GroupThreadID)
 {
-    uint max_probe_spawn_count = (g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size
-                               * (g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size;
+    uint max_probe_spawn_count = ((g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size)
+                               * ((g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size);
     uint probe_count           = g_ScreenProbes_ProbeSpawnScanBuffer[max_probe_spawn_count - 1]
                                + g_ScreenProbes_ProbeSpawnIndexBuffer[max_probe_spawn_count - 1];
 
@@ -1352,8 +1352,8 @@ void ReorderScreenProbes(in uint did : SV_DispatchThreadID)
 [numthreads(64, 1, 1)]
 void FilterScreenProbes(in uint did : SV_DispatchThreadID)
 {
-    uint max_probe_spawn_count = (g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size
-                               * (g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size;
+    uint max_probe_spawn_count = ((g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size)
+                               * ((g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size);
     uint probe_count           = g_ScreenProbes_ProbeSpawnScanBuffer[max_probe_spawn_count - 1]
                                + g_ScreenProbes_ProbeSpawnIndexBuffer[max_probe_spawn_count - 1];
 
@@ -1441,8 +1441,8 @@ void FilterScreenProbes(in uint did : SV_DispatchThreadID)
 [numthreads(64, 1, 1)]
 void ProjectScreenProbes(in uint did : SV_DispatchThreadID, in uint local_id : SV_GroupThreadID)
 {
-    uint max_probe_spawn_count = (g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size
-                               * (g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size;
+    uint max_probe_spawn_count = ((g_BufferDimensions.x + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size)
+                               * ((g_BufferDimensions.y + g_ScreenProbesConstants.probe_spawn_tile_size - 1) / g_ScreenProbesConstants.probe_spawn_tile_size);
     uint probe_count           = g_ScreenProbes_ProbeSpawnScanBuffer[max_probe_spawn_count - 1]
                                + g_ScreenProbes_ProbeSpawnIndexBuffer[max_probe_spawn_count - 1];
 

--- a/src/core/src/render_techniques/gi10/gi10.comp
+++ b/src/core/src/render_techniques/gi10/gi10.comp
@@ -3705,7 +3705,7 @@ void FilterBlurMask(in uint2 did : SV_DispatchThreadID, in uint2 lid : SV_GroupT
         {
             for (int x = -kGIDenoiser_BlurRadius; x <= kGIDenoiser_BlurRadius; ++x)
             {
-                if (x != 0 && y != 0)   // center element was already processed
+                if(x != 0 || y != 0) // center element was already processed
                 {
                     float s = GIDenoiser_TapBlurMask(tile_pos + float2(x, y));
                     float d = sqrt(float(x * x + y * y));

--- a/src/core/src/render_techniques/gi10/gi10.cpp
+++ b/src/core/src/render_techniques/gi10/gi10.cpp
@@ -108,8 +108,8 @@ void GI10::ScreenProbes::ensureMemoryIsAllocated(CapsaicinInternal const &capsai
     uint32_t const probe_mask_mip_count = gfxCalculateMipCount(probe_count[0], probe_count[1]);
 
     uint32_t const max_probe_count = probe_count[0] * probe_count[1];
-    max_probe_spawn_count          = (buffer_width + probe_spawn_tile_size_ - 1) / probe_spawn_tile_size_
-                          * (buffer_height + probe_spawn_tile_size_ - 1) / probe_spawn_tile_size_;
+    max_probe_spawn_count          = ((buffer_width + probe_spawn_tile_size_ - 1) / probe_spawn_tile_size_)
+                          * ((buffer_height + probe_spawn_tile_size_ - 1) / probe_spawn_tile_size_);
 
     max_ray_count = max_probe_spawn_count * probe_size_ * probe_size_;
 

--- a/src/core/src/render_techniques/gi10/gi_denoiser.hlsl
+++ b/src/core/src/render_techniques/gi10/gi_denoiser.hlsl
@@ -23,6 +23,10 @@ THE SOFTWARE.
 #ifndef GI_DENOISER_HLSL
 #define GI_DENOISER_HLSL
 
+// Blur mask texture format is R8_SNORM, with -1 encoding sky pixels and [0, 127] (actually [0, 8]) encoding the blur radius
+#define kGIDenoiser_BlurMaskUnpack 127.f
+#define kGIDenoiser_BlurMaskPack   (1.f / kGIDenoiser_BlurMaskUnpack)
+
 #define kGIDenoiser_BlurRadius    4
 #define kGIDenoiser_BlurGroupSize 8
 #define kGIDenoiser_BlurTileDim  (2 * kGIDenoiser_BlurRadius + kGIDenoiser_BlurGroupSize)


### PR DESCRIPTION
Because of precedence,
```((buffer_width + probe_spawn_tile_size_ - 1) / probe_spawn_tile_size_ * (buffer_height + probe_spawn_tile_size_ - 1)) / probe_spawn_tile_size_```
is performed instead of
```((buffer_width + probe_spawn_tile_size_ - 1) / probe_spawn_tile_size_) * ((buffer_height + probe_spawn_tile_size_ - 1) / probe_spawn_tile_size_)```