### PR TITLE
FilterBlurMask pass: fix unpacking/packing of blur mask from/to R8_SNORM

### DIFF
--- a/src/core/src/render_techniques/gi10/gi10.comp
+++ b/src/core/src/render_techniques/gi10/gi10.comp
@@ -3656,7 +3656,7 @@ void ReprojectGI(in uint2 did : SV_DispatchThreadID)
         lighting *= (max_sample_count / lighting.w);
     }
 
-    g_GIDenoiser_BlurMask[did]         = blur_mask / 127.0f;
+    g_GIDenoiser_BlurMask[did]         = blur_mask * kGIDenoiser_BlurMaskPack;
     g_GIDenoiser_ColorBuffer[did]      = lighting;
     g_GIDenoiser_ColorDeltaBuffer[did] = color_delta;
 }
@@ -3678,10 +3678,10 @@ void FilterBlurMask(in uint2 did : SV_DispatchThreadID, in uint2 lid : SV_GroupT
         int2 coord3 = anchor + int2((local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim / 2)     % kGIDenoiser_BlurTileDim, (local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim / 2)     / kGIDenoiser_BlurTileDim);
         int2 coord4 = anchor + int2((local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim * 3 / 4) % kGIDenoiser_BlurTileDim, (local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim * 3 / 4) / kGIDenoiser_BlurTileDim);
 
-        float blur_mask_0 = g_GIDenoiser_BlurMask[clamp(coord1, 0, int2(g_BufferDimensions) - 1)].x;
-        float blur_mask_1 = g_GIDenoiser_BlurMask[clamp(coord2, 0, int2(g_BufferDimensions) - 1)].x;
-        float blur_mask_2 = g_GIDenoiser_BlurMask[clamp(coord3, 0, int2(g_BufferDimensions) - 1)].x;
-        float blur_mask_3 = g_GIDenoiser_BlurMask[clamp(coord4, 0, int2(g_BufferDimensions) - 1)].x;
+        float blur_mask_0 = g_GIDenoiser_BlurMask[clamp(coord1, 0, int2(g_BufferDimensions) - 1)].x * kGIDenoiser_BlurMaskUnpack;
+        float blur_mask_1 = g_GIDenoiser_BlurMask[clamp(coord2, 0, int2(g_BufferDimensions) - 1)].x * kGIDenoiser_BlurMaskUnpack;
+        float blur_mask_2 = g_GIDenoiser_BlurMask[clamp(coord3, 0, int2(g_BufferDimensions) - 1)].x * kGIDenoiser_BlurMaskUnpack;
+        float blur_mask_3 = g_GIDenoiser_BlurMask[clamp(coord4, 0, int2(g_BufferDimensions) - 1)].x * kGIDenoiser_BlurMaskUnpack;
 
         lds_GIDenoiser_BlurMask[local_id]                                                             = blur_mask_0;
         lds_GIDenoiser_BlurMask[local_id + kGIDenoiser_BlurTileDim * kGIDenoiser_BlurTileDim / 4]     = blur_mask_1;
@@ -3725,7 +3725,7 @@ void FilterBlurMask(in uint2 did : SV_DispatchThreadID, in uint2 lid : SV_GroupT
         InterlockedAdd(g_GIDenoiser_BlurSampleCountBuffer[0], lds_GIDenoiser_BlurSampleCount);
     }
 
-    g_GIDenoiser_BlurredBlurMask[did] = blur_mask;
+    g_GIDenoiser_BlurredBlurMask[did] = blur_mask * kGIDenoiser_BlurMaskPack;
 }
 
 [numthreads(8, 8, 1)]

--- a/src/core/src/render_techniques/gi10/gi_denoiser.hlsl
+++ b/src/core/src/render_techniques/gi10/gi_denoiser.hlsl
@@ -23,6 +23,10 @@ THE SOFTWARE.
 #ifndef GI_DENOISER_HLSL
 #define GI_DENOISER_HLSL
 
+// Blur mask texture format is R8_SNORM, with -1 encoding sky pixels and [0, 127] (actually [0, 8]) encoding the blur radius
+#define kGIDenoiser_BlurMaskUnpack 127.f
+#define kGIDenoiser_BlurMaskPack   (1.f / kGIDenoiser_BlurMaskUnpack)
+
 #define kGIDenoiser_BlurRadius    4
 #define kGIDenoiser_BlurGroupSize 8
 #define kGIDenoiser_BlurTileDim  (2 * kGIDenoiser_BlurRadius + kGIDenoiser_BlurGroupSize)


### PR DESCRIPTION
The FilterBlurMask was not blurring the mask because there are the unpack/packing from and to R8_SNORM that are missing.
The blurring seems to work with these changes but I am unsure about the impact on frame stability...